### PR TITLE
Ensure transfer to GPU

### DIFF
--- a/model/utils.py
+++ b/model/utils.py
@@ -24,13 +24,9 @@ def set_default_device_cuda(device='gpu'):
     """Sets the default device (cpu or cuda) used for all tensors."""
     if not torch.cuda.is_available() or (device == 'cpu'):
         device = torch.device('cpu')
-        tensor = torch.FloatTensor
-        torch.set_default_tensor_type(tensor)
         return device
     elif (device in ['gpu', 'cuda']) and torch.cuda.is_available():  # device_name == "cuda":
         device = torch.device('cuda')
-        tensor = torch.cuda.FloatTensor  # pylint: disable=E1101
-        torch.set_default_tensor_type(tensor)
         return device
     elif torch.cuda.is_available(): # Assume an index
         raise NotImplementedError


### PR DESCRIPTION
Thanks for the code

I had a few problems with using the code with PyTorch v1.9.1. I would suggest the following updates to the code base, mainly explicit calls to transfer data to GPU. Or perhaps something similar?

- Ensure transfer to GPU using the method `to(device)`
- Remove set_`default_tensor_type()`, this caused problems, for example, with `enumerate(tqdm(dataloader, total=len(dataloader)))`